### PR TITLE
Fixed user deletion (2026-02)

### DIFF
--- a/app/Models/PlayerMeta.php
+++ b/app/Models/PlayerMeta.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Model;
+
+class PlayerMeta extends Model
+{
+    /**
+     * The table associated with the model.
+     *
+     * @var string
+     */
+    protected $table = 'playermeta';
+
+    protected $fillable = [
+        'uid', 'meta_key', 'meta_value'
+    ];
+
+    // Assuming 'uid' is the foreign key for the user ID from the registration
+
+    /**
+     * Get the user associated with the PlayerMeta.
+     */
+    public function user()
+    {
+        return $this->belongsTo(User::class, 'uid');
+    }
+}

--- a/database/migrations/0001_01_01_000000_create_users_table.php
+++ b/database/migrations/0001_01_01_000000_create_users_table.php
@@ -68,6 +68,8 @@ return new class extends Migration
             $table->string('uid', 20);
             $table->string('meta_key', 255);
             $table->longText('meta_value');
+            $table->timestamp('created_at')->useCurrent();
+            $table->timestamp('updated_at')->useCurrent()->useCurrentOnUpdate();
         });
 
         Schema::create('userworlds', function (Blueprint $table) {


### PR DESCRIPTION
These changes:
- Create a PlayerMeta model
- Add timestamps to the PlayerMeta table as expected by its model
- Close #38

Testing was performed on:
- My Windows 11 host
- A fresh Xubuntu 24.04.3 guest
- A fresh Debian 13.3.0 guest

I found no feature regressions.

**NOTE:** If someone visits a deleted user intermittently, a new farm is created to prevent a crash. If a new user inherits the deleted user's uid, they will also inherit this plot data. I am leaving this untouched for now, as it exceeds the scope of this PR.